### PR TITLE
Fix grammar on editors page

### DIFF
--- a/docs/writing/editors.md
+++ b/docs/writing/editors.md
@@ -12,7 +12,7 @@ menu:
         parent: "writing"        
 ---
 
-There are two options for writing Yarn your scripts.
+There are two options for writing your Yarn scripts.
 
 ## The Yarn Editor
 


### PR DESCRIPTION
"There are two options for writing **Yarn** **your** scripts."

Swapped those two around so it makes sense.