### PR TITLE
Removes period after manual install url

### DIFF
--- a/docs/unity/installing.md
+++ b/docs/unity/installing.md
@@ -50,7 +50,7 @@ If you're using Unity 2019.3 or later, you can add the package directly:
 
 {{< img "v1.1/installing-package-manager-git-url.png" "Adding a package using a Git URL." >}}
 
-1. Enter the following URL: **`https://github.com/YarnSpinnerTool/YarnSpinner-Unity.git`**.
+1. Enter the following URL: **`https://github.com/YarnSpinnerTool/YarnSpinner-Unity.git`**
 2. The project will download and install.
 
 #### Unity 2018.4 to Unity 2019.2


### PR DESCRIPTION
Some people (like me) might copy/paste the whole url and it won't work with the dot at the end.
I should know better, but some might not.